### PR TITLE
Potential fix for code scanning alert no. 69: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/eng618/eng618.github.io/security/code-scanning/69](https://github.com/eng618/eng618.github.io/security/code-scanning/69)

To fix the problem, the workflow should declare a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal permissions required. Since this job only checks out code and runs Node-based build/test commands, it only needs read access to repository contents; it does not need to write to the repo or interact with issues or pull requests.

The best fix without changing existing functionality is to add `permissions: contents: read` at the workflow (top) level, right after the `on:` block and before `jobs:`. This will apply to all jobs in the workflow that do not define their own `permissions:` block. No steps currently require additional scopes (like `pull-requests: write` or `contents: write`), so `contents: read` is sufficient and least-privilege. No imports or external libraries are involved, as this is a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/build-and-deploy.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (after line 9/10 in the snippet) and before `jobs:` (line 11). No other lines need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
